### PR TITLE
Fix .Numberize to be RFC 8259 compliant and not throw on Bulgarian systems.

### DIFF
--- a/SimpleLongJSON.cs
+++ b/SimpleLongJSON.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Collections;
-
+using System.Globalization;
 
 /* * * * *
  * A simple JSON Parser / builder
@@ -311,23 +311,22 @@ namespace SimpleLongJSON
 
         static JSONData Numberize(string token)
         {
-
             bool flag = false;
             int integer = 0;
             long longer = 0;
             double real = 0;
 
-            if (int.TryParse(token, out integer))
+            if (int.TryParse(token, NumberStyles.Integer, CultureInfo.InvariantCulture, out integer))
             {
                 return new JSONData(integer);
             }
 
-            if (Int64.TryParse(token, out longer)) {
+            if (Int64.TryParse(token, NumberStyles.Integer, CultureInfo.InvariantCulture, out longer))
+            {
                 return new JSONData(longer);
             }
-            
 
-            if (double.TryParse(token, out real))
+            if (double.TryParse(token, NumberStyles.Any, CultureInfo.InvariantCulture, out real))
             {
                 return new JSONData(real);
             }
@@ -521,7 +520,8 @@ namespace SimpleLongJSON
                                         string s = aJSON.Substring(i + 1, 4);
                                         Token += (char)int.Parse(
                                             s,
-                                            System.Globalization.NumberStyles.AllowHexSpecifier);
+                                            System.Globalization.NumberStyles.AllowHexSpecifier, 
+                                            CultureInfo.InvariantCulture);
                                         i += 4;
                                         break;
                                     }


### PR DESCRIPTION
C# has context of thread Globalization setting, the Thread Culture, and on some non-english systems, e.g. in Bulgarian, float.Parse excepts a comma instead of a dot while parsing. Which causes bugs and exceptions, especially a "NotImplementedException" when passing the string "1.234" while it expects "1,234".

I've fixed the library to explicitly pass InvariantCulture to these parse methods, respecting RFC 8259, forcing JSON-compliance and no "NotImplementedException" being thrown.